### PR TITLE
bug fix in workbox-config.js issue #2

### DIFF
--- a/workbox-config.js
+++ b/workbox-config.js
@@ -3,6 +3,6 @@ module.exports = {
   "globPatterns": [
     "**/*.{html,css,ttf,woff,woff2,png,svg,js,ico,json,xml,gz}"
   ],
-  "swDest": "site\\sw.js",
+  "swDest": "site/sw.js",
   "swSrc": "sw-src.js"
 };


### PR DESCRIPTION
Should be a single forward slash, not two backslashes.
The current code ends up deploying a file called "site\sw.js"
in the root directory "/" when it should be putting the file
"sw.js" into the "/site/" directory.